### PR TITLE
fix: adjust functions to allow for a clean deletion

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -105,7 +105,7 @@ module "bastion_autoscale_group" {
   default_cooldown            = 300
   scale_down_cooldown_seconds = 300
   wait_for_capacity_timeout   = "10m"
-  user_data_base64            = join("", data.cloudinit_config.config[0][*].rendered)
+  user_data_base64            = try(data.cloudinit_config.config[0].rendered, null)
   tags                        = module.this.tags
   security_group_ids          = [module.sg.id]
   iam_instance_profile_name   = join("", aws_iam_instance_profile.default[*].name)

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -4,7 +4,7 @@ output "autoscaling_group_id" {
 }
 
 output "iam_instance_profile" {
-  value       = join("", aws_iam_instance_profile.default[*].name)
+  value       = one(aws_iam_instance_profile.default[*].name)
   description = "Name of AWS IAM Instance Profile"
 }
 


### PR DESCRIPTION
## what

- When the following command is ran on the component, the deletion fails:

```sh
# Destroy resources
atmos terraform destroy bastion -s <stack>
```

Error:

```console
╷
│ Error: Invalid index
│
│   on main.tf line 132, in module "bastion_autoscale_group":
│  132:   user_data_base64            = join("", data.cloudinit_config.config[0][*].rendered)
│     ├────────────────
│     │ data.cloudinit_config.config is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
Releasing state lock. This may take a few moments...
```

## why

- `data.cloudinit_config.config` is a list with count = 0 or 1
- We're accessing the first (and only) element when it exists
- We want a safe fallback when it’s disabled
- Clean up outputs when disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during initialization to gracefully handle missing configuration details.
  - Updated output derivation for profile information, ensuring more consistent and reliable data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->