### PR TITLE
Add configurable VPC component

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ components:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_vpc_component_name"></a> [vpc_component_name](#input_vpc_component_name) | Name of the VPC component to look up via remote state | `string` | `"vpc"` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -131,7 +131,8 @@ description: |-
   | <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of maps of Security Group rules.<br>The values of map is fully completed with `aws_security_group_rule` resource.<br>To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule . | `list(any)` | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "from_port": 0,<br>    "protocol": -1,<br>    "to_port": 0,<br>    "type": "egress"<br>  },<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "from_port": 22,<br>    "protocol": "tcp",<br>    "to_port": 22,<br>    "type": "ingress"<br>  }<br>]</pre> | no |
   | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
   | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-  | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_vpc_component_name"></a> [vpc_component_name](#input_vpc_component_name) | Name of the VPC component to look up via remote state | `string` | `"vpc"` | no |
 
   ## Outputs
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -73,3 +73,9 @@ variable "image_container" {
   default     = ""
   description = "The image container to use in `container.sh`."
 }
+
+variable "vpc_component_name" {
+  type        = string
+  default     = "vpc"
+  description = "Name of the VPC component to look up via remote state"
+}


### PR DESCRIPTION
## Summary
- allow customizing which VPC component to query via remote state

## Testing
- `make test`
- `make readme` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_b_68598513e794832b81a57328c4de0fa3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configurable input for specifying the name of the VPC component to look up via remote state, with a default value provided.
- **Documentation**
  - Updated documentation to reflect the new input variable and its details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->